### PR TITLE
add the ability to switch fonts while creating pdf documents, setFont()

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,12 +69,13 @@ node.js</a> version is better.</h3><br/>
 <span id = "pdfLink"></span>
 <br/>
 <textarea id = "theCode" class = "box">
-
   /* create the PDF document */
   
     var doc = new pdf();
     doc.text(20, 20, 'hello, I am PDF.');
+    doc.setFont('Courier');
     doc.text(20, 30, 'i was created in the browser using javascript.');
+    doc.setFont('Times-Roman');
     doc.text(20, 40, 'i can also be created from node.js');
   
     /* optional - set properties on the document */
@@ -88,10 +89,15 @@ node.js</a> version is better.</h3><br/>
     doc.addPage();
 
     doc.setFontSize(22);
+    doc.setFont('Verdana');
     doc.text(20, 20, 'This is a title');
 
     doc.setFontSize(16);
-    doc.text(20, 30, 'This is some normal sized text underneath.');
+    doc.text(20, 30, 'You can also override page fonts with text method', 'Times-Roman');
+    doc.text(20, 40, 'Monaco -This is some normal sized text underneath.', 'Monaco');
+    doc.text(20, 50, 'Times-Roman - This is some normal sized text underneath.', 'Times-Roman');
+    doc.text(20, 60, 'Helvetica - This is some normal sized text underneath.', 'Helvetica');
+    doc.text(20, 70, 'Courier - This is some normal sized text.', 'Courier');
 
     doc.drawLine(100, 100, 100, 120, 1.0, 'dashed');
     doc.drawLine(100, 100, 120, 100, 1.2, 'dotted');
@@ -120,6 +126,7 @@ node.js</a> version is better.</h3><br/>
     // create a link
     // this seems to always work, except clicking the link destroys my FF instantly 
     $('#pdfLink').html('<a href = "'+pdfAsDataURI+'">'+fileName+'</a> <span class = "helper">right click and save file as pdf</span');
+
 
 </textarea>
 </form>

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -44,7 +44,7 @@ var pdf = exports.pdf = function(){
   var documentProperties = {};
   var fontSize = 16; // Default font size
   var pageFontSize = 16;
-  var font = 'Courier'; // Default font
+  var font = 'Helvetica'; // Default font
   var pageFont = font;
   var fonts = {}; // fonts holder, namely use in putRessource
   var fontIndex = 0; // F1, F2, etc. using setFont

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -124,7 +124,7 @@ var pdf = exports.pdf = function(){
       }
     } else {
       // if fontIndex still 0, means that setFont was not used, fallback to default
-      fonts[font] = 1;
+      fonts[font] = 0;
       putFonts(font);            
     }
 
@@ -335,7 +335,7 @@ var pdf = exports.pdf = function(){
       }
       
       var str = sprintf('BT %.2f %.2f Td (%s) Tj ET', x * k, (pageHeight - y) * k, pdfEscape(text))   
-      out('BT ' + fonts[font] + ' ' + parseInt(fontSize, 10) + '.00 Tf ET');
+      out('BT ' + (fonts[font] ? fonts[font] : '/F0') + ' ' + parseInt(fontSize, 10) + '.00 Tf ET');
       out(str);
     },
     drawRect: function(x, y, w, h, style) {

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -41,10 +41,14 @@ var pdf = exports.pdf = function(){
   var pageHeight;
   var k; // Scale factor
   var unit = 'mm'; // Default to mm for units
-  var fontNumber; // TODO: This is temp, replace with real font handling
   var documentProperties = {};
   var fontSize = 16; // Default font size
   var pageFontSize = 16;
+  var font = 'Courier'; // Default font
+  var pageFont = font;
+  var fonts = {}; // fonts holder, namely use in putRessource
+  var fontIndex = 0; // F1, F2, etc. using setFont
+  var fontsNumber = {}; // object number holder for fonts
 
   // Initilisation 
   if (unit == 'pt') {
@@ -112,7 +116,19 @@ var pdf = exports.pdf = function(){
   }
   
   var putResources = function() {
-    putFonts();
+    var f;
+    // Deal with fonts, defined in fonts by user (using setFont).
+    if(fontIndex) {
+      for( f in fonts ) {
+        putFonts(f);
+      }
+    } else {
+      // if fontIndex still 0, means that setFont was not used, fallback to default
+      fonts[font] = 1;
+      putFonts(font);            
+    }
+
+    
     putImages();
     
     //Resource dictionary
@@ -124,13 +140,12 @@ var pdf = exports.pdf = function(){
     out('endobj');
   } 
   
-  var putFonts = function() {
-    // TODO: Only supports core font hardcoded to Helvetica
+  var putFonts = function(font) {
     newObject();
-    fontNumber = objectNumber;
-    name = 'Helvetica';
+    fontsNumber[font] = objectNumber;
+    
     out('<</Type /Font');
-    out('/BaseFont /' + name);
+    out('/BaseFont /' + font);
     out('/Subtype /Type1');
     out('/Encoding /WinAnsiEncoding');
     out('>>');
@@ -163,11 +178,17 @@ var pdf = exports.pdf = function(){
   };
   
   var putResourceDictionary = function() {
+    var i = 0, index, fx;
+    
     out('/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]');
     out('/Font <<');
+    
     // Do this for each font, the '1' bit is the index of the font
-        // fontNumber is currently the object number related to 'putFonts'
-    out('/F1 ' + fontNumber + ' 0 R');
+    // fontNumber is currently the object number related to 'putFonts'
+    for( index in fontsNumber ) {
+      out(fonts[index] + ' ' + fontsNumber[index] + ' 0 R');
+    }
+    
     out('>>');
     out('/XObject <<');
     putXobjectDict();
@@ -284,10 +305,10 @@ var pdf = exports.pdf = function(){
     // Set line width
     out(sprintf('%.2f w', (lineWidth * k)));
     
-    // Set font - TODO
     // 16 is the font size
     pageFontSize = fontSize;
-    out('BT /F1 ' + parseInt(fontSize) + '.00 Tf ET');    
+    pageFont = font;
+    out('BT ' + fonts[font] + ' ' + parseInt(fontSize) + '.00 Tf ET');    
   }
   
   // Add the first page automatically
@@ -302,13 +323,19 @@ var pdf = exports.pdf = function(){
     addPage: function() {
       _addPage();
     },
-    text: function(x, y, text) {
-      // need page height
-      if(pageFontSize != fontSize) {
-        out('BT /F1 ' + parseInt(fontSize) + '.00 Tf ET');
-        pageFontSize = fontSize;
+    text: function(x, y, text, f) {
+      if(f) {
+        this.setFont(f);
       }
-      var str = sprintf('BT %.2f %.2f Td (%s) Tj ET', x * k, (pageHeight - y) * k, pdfEscape(text));
+      
+      // need either page height or page font
+      if(pageFontSize !== fontSize || pageFont !== font) {
+        pageFontSize = fontSize;
+        pageFont = font;
+      }
+      
+      var str = sprintf('BT %.2f %.2f Td (%s) Tj ET', x * k, (pageHeight - y) * k, pdfEscape(text))   
+      out('BT ' + fonts[font] + ' ' + parseInt(fontSize, 10) + '.00 Tf ET');
       out(str);
     },
     drawRect: function(x, y, w, h, style) {
@@ -339,6 +366,14 @@ var pdf = exports.pdf = function(){
     },
     setFontSize: function(size) {
       fontSize = size;
+    },
+    setFont: function(f){
+      if( !(f in fonts) ) {
+        // if not known font yet, add in fonts array, then used in endDocument
+        // while putting ressource
+        fonts[f] = '/F' + (fontIndex++);
+      }
+      font = f;
     }
   }
 


### PR DESCRIPTION
also made it possible to specify font with `text(x, y, text, font)` which internally just calls `setFont`.

This code may be further optimized/cleaned up but basic fonts handling is provided :)
