### PR TITLE
No text was displaying in the generated file without these changes

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -208,7 +208,7 @@ var pdf = exports.pdf = function(){
     // Do this for each font, the '1' bit is the index of the font
     // fontNumber is currently the object number related to 'putFonts'
     for( index in fontsNumber ) {
-      out(fonts[index] + ' ' + fontsNumber[index] + ' 0 R');
+      out('/F'+fonts[index] + ' ' + fontsNumber[index] + ' 0 R');
     }
     
     out('>>');
@@ -330,7 +330,9 @@ var pdf = exports.pdf = function(){
     // 16 is the font size
     pageFontSize = fontSize;
     pageFont = font;
-    out('BT ' + fonts[font] + ' ' + parseInt(fontSize) + '.00 Tf ET');    
+    if (fonts[font]) {
+      out('BT ' + fonts[font] + ' ' + parseInt(fontSize) + '.00 Tf ET');    
+    }
   }
   
   // Add the first page automatically


### PR DESCRIPTION
Even though Mac Preview started displaying the pdf correctly after the change in line 211, Adobe reader still refused citing an error about font being undefined. This was corrected by the modification in line 333.
Works well now.
